### PR TITLE
feat(i18n): add behavior to localize elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
     "vaadin-text-field": "vaadin/vaadin-text-field#^2.3.5",
     "vaadin-button": "vaadin/vaadin-button#^2.1.4",
     "hostabee-profile-picture": "^1.0.0",
-    "iron-collapse": "PolymerElements/iron-collapse#^2.2.1"
+    "iron-collapse": "PolymerElements/iron-collapse#^2.2.1",
+    "app-localize-behavior": "PolymerElements/app-localize-behavior#^2.0.0"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",

--- a/hostabee-comment-create-form.html
+++ b/hostabee-comment-create-form.html
@@ -4,7 +4,7 @@ Copyright (c) 2019 Hostabee SAS.
 This program is available under Apache License Version 2.0.
 -->
 
-<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="./hostabee-element.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../vaadin-text-field/vaadin-text-area.html">
 <link rel="import" href="../vaadin-button/vaadin-button.html">
@@ -46,6 +46,7 @@ This program is available under Apache License Version 2.0.
 
       .actions vaadin-button {
         margin-left: 8px;
+        text-transform: capitalize;
       }
 
       .horizontal {
@@ -61,13 +62,13 @@ This program is available under Apache License Version 2.0.
       <template is="dom-if" if="[[author]]">
         <hostabee-profile-picture src="[[author]]" size="38"></hostabee-profile-picture>
       </template>
-      <vaadin-text-area placeholder="Write a comment..." minlength="20" error-message="At least 20 chars" onkeydown="[[_handleKeyDown()]]" value="{{value}}" required></vaadin-text-area>
+      <vaadin-text-area placeholder="[[localize('PLACEHOLDER_write_a_comment')]]" minlength="20" error-message="[[localize('ERROR_at_least_20_chars')]]" onkeydown="[[_handleKeyDown()]]" value="{{value}}" required></vaadin-text-area>
     </div>
 
     <template is="dom-if" if="[[actionButtonsVisible]]">
       <div class="actions">
-        <vaadin-button theme="small" on-click="cancel">Cancel</vaadin-button>
-        <vaadin-button theme="primary small" on-click="confirm">Save</vaadin-button>
+        <vaadin-button theme="small" on-click="cancel">[[localize('cancel')]]</vaadin-button>
+        <vaadin-button theme="primary small" on-click="confirm">[[localize('save')]]</vaadin-button>
       </div>
     </template>
 
@@ -86,7 +87,7 @@ This program is available under Apache License Version 2.0.
      * @memberof Hostabee
      * @demo demo/hostabee-comment-create-form/basic.html Basic
      */
-    class HostabeeCommentCreateForm extends Polymer.Element {
+    class HostabeeCommentCreateForm extends Hostabee.Element {
 
       static get is() {
         return 'hostabee-comment-create-form';

--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -4,7 +4,7 @@ Copyright (c) 2019 Hostabee SAS.
 This program is available under Apache License Version 2.0.
 -->
 
-<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="./hostabee-element.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="./hostabee-comment.html">
@@ -53,7 +53,7 @@ This program is available under Apache License Version 2.0.
      * @demo demo/hostabee-comment-flow/read-only.html Read only
      * @demo demo/hostabee-comment-flow/with-mapper.html With mapper
      */
-    class HostabeeCommentFlow extends Polymer.Element {
+    class HostabeeCommentFlow extends Hostabee.Element {
 
       static get is() {
         return 'hostabee-comment-flow';

--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -4,7 +4,7 @@ Copyright (c) 2019 Hostabee SAS.
 This program is available under Apache License Version 2.0.
 -->
 
-<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="./hostabee-element.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../polymer/lib/elements/dom-if.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
@@ -53,6 +53,10 @@ This program is available under Apache License Version 2.0.
         font-size: 0.95em;
       }
 
+      .summary__date>i {
+        text-transform: capitalize;
+      }
+
       .content {
         padding: 10px 5px 0 5px;
         color: var(--primary-text-color, rgba(0, 0, 0, 0.7));
@@ -66,6 +70,7 @@ This program is available under Apache License Version 2.0.
       .menu-item {
         border-radius: 0;
         margin: 0;
+        text-transform: capitalize;
       }
 
       .menu-item:hover {
@@ -88,15 +93,16 @@ This program is available under Apache License Version 2.0.
 
       .actions vaadin-button {
         margin-left: 8px;
+        text-transform: capitalize;
       }
     </style>
 
     <div class="heading">
       <hostabee-profile-picture src="[[item.author]]"></hostabee-profile-picture>
       <div class="summary">
-        <span class="summary__author-name">[[getAuthorName(item.author)]]</span>
+        <span class="summary__author-name">[[authorName]]</span>
         <div class="summary__date">
-          <i hidden$="[[!item.updated]]">Modified:</i>
+          <i hidden$="[[!item.updated]]">[[localize('modified')]]:</i>
           <span>[[getDateLastEdit(item)]]</span>
         </div>
       </div>
@@ -106,11 +112,11 @@ This program is available under Apache License Version 2.0.
         <div slot="dropdown-content" class="dropdown-content">
           <vaadin-button class="menu-item" theme="contrast" on-tap="edit">
             <iron-icon slot="prefix" icon="hostabee-icons:edit"></iron-icon>
-            Edit
+            [[localize('edit')]]
           </vaadin-button>
           <vaadin-button class="menu-item" theme="error" on-tap="delete">
             <iron-icon slot="prefix" icon="hostabee-icons:delete"></iron-icon>
-            Delete
+            [[localize('delete')]]
           </vaadin-button>
         </div>
       </paper-menu-button>
@@ -126,10 +132,10 @@ This program is available under Apache License Version 2.0.
         </vaadin-button>
       </template>
       <template is="dom-if" if="[[editing]]">
-        <vaadin-text-area label="Edit your comment" minlength="20" error-message="At least 20 chars" value="[[item.content]]" onkeydown="[[_handleKeyDown()]]" autofocus required></vaadin-text-area>
+        <vaadin-text-area label="[[localize('LABEL_edit_your_comment')]]" minlength="20" error-message="[[localize('ERROR_at_least_20_chars')]]" value="[[item.content]]" onkeydown="[[_handleKeyDown()]]" autofocus required></vaadin-text-area>
         <div class="actions">
-          <vaadin-button theme="small" on-tap="cancelEdit">Cancel</vaadin-button>
-          <vaadin-button theme="primary small" on-tap="confirmEdit">Save</vaadin-button>
+          <vaadin-button theme="small" on-tap="cancelEdit">[[localize('cancel')]]</vaadin-button>
+          <vaadin-button theme="primary small" on-tap="confirmEdit">[[localize('save')]]</vaadin-button>
         </div>
       </template>
     </div>
@@ -152,7 +158,7 @@ This program is available under Apache License Version 2.0.
      * @demo demo/hostabee-comment/no-author.html Without author
      * @demo demo/hostabee-comment/with-momentjs.html With MomentJs in your app
      */
-    class HostabeeComment extends Polymer.Element {
+    class HostabeeComment extends Hostabee.Element {
 
       static get is() {
         return 'hostabee-comment';
@@ -248,22 +254,21 @@ This program is available under Apache License Version 2.0.
             type: Boolean,
             computed: '__computeIsShort(item.content)',
           },
+          /**
+           * Author name. In the order, check the `fullname` property then the
+           * `name`. If `author` is not defined the name is "Anonymous".
+           *
+           * @type {String}
+           */
+          authorName: {
+            type: String,
+            computed: '__computeAuthorName(item.author, resources)',
+          },
           _toggleButtonText: {
             type: String,
-            computed: '__computeToggleButtonText(opened)',
+            computed: '__computeToggleButtonText(opened, language)',
           },
         };
-      }
-
-      /**
-       * Gets the author name. In the order, check the `fullname` property then
-       * the `name`. If `author` is not defined, the returned name is "Anonymous".
-       * 
-       * @param {Object} author The author of the comment.
-       * @return {String} The name of the author.
-       */
-      getAuthorName(author) {
-        return !author ? 'Anonymous' : author.fullname || author.name || 'Anonymous';
       }
 
       /**
@@ -417,8 +422,17 @@ This program is available under Apache License Version 2.0.
         return isShort;
       }
 
+      __computeAuthorName(author) {
+        let name = author && (author.fullname || author.name);
+        return name || this.localize('anonymous', 'capitalize', 'yes') || 'Anonymous';
+      }
+
       __computeToggleButtonText() {
-        return !this.opened ? 'read more' : 'show less';
+        if (!this.resources) {
+          return !this.opened ? 'read more' : 'show less';
+        } else {
+          return this.localize(!this.opened ? 'read_more' : 'show_less');
+        }
       }
 
       /**

--- a/hostabee-element-mixin.html
+++ b/hostabee-element-mixin.html
@@ -1,0 +1,115 @@
+<!--
+@license
+Copyright (c) 2019 Hostabee SAS.
+This program is available under Apache License Version 2.0.
+-->
+<link rel="import" href="../polymer/lib/legacy/class.html">
+<link rel="import" href="../polymer/lib/utils/mixin.html">
+<link rel="import" href="../app-localize-behavior/app-localize-behavior.html">
+
+<script>
+  (function() {
+    'user strict';
+
+    /**
+     * @namespace Hostabee
+     */
+    window.Hostabee = window.Hostabee || {};
+
+    /**
+     * @mixinFunction
+     * @polymer
+     * @memberof Hostabee
+     */
+    const ElementMixin = (superClass) => class extends Polymer.mixinBehaviors(
+      [Polymer.AppLocalizeBehavior], superClass) {
+
+      static get is() {
+        return 'hostabee-element';
+      }
+
+      static get properties() {
+        return {
+          language: {
+            type: String,
+            value: window.navigator.language,
+          },
+          /**
+           * Path to an external file containing locales. If the value is set, the
+           * target file will be used instead of the default one. The target file
+           * must be in JSON format.
+           *
+           * For more detail about the file format, please read the
+           * [AppLocalizeBehavior](https://github.com/PolymerElements/app-localize-behavior)
+           * documentation.
+           *
+           * @type {String}
+           */
+          localesFile: {
+            type: String,
+            observer: '_localesFileChanged',
+          },
+        };
+      }
+
+      static get observers() {
+        return [
+          '_onLanguageChanged(language)',
+        ];
+      }
+
+      /**
+       * Called every time the element is inserted into the DOM. Useful for 
+       * running setup code, such as fetching resources or rendering.
+       * Generally, you should try to delay work until this time.
+       */
+      connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('app-localize-resources-error',
+          this._unregionalize.bind(this));
+      }
+
+      /**
+       * Called every time the element is removed from the DOM. Useful for 
+       * running clean up code (removing event listeners, etc.).
+       */
+      disconnectedCallback() {
+        super.disconnectedCallback();
+        this.removeEventListener('app-localize-resources-error',
+          this._unregionalize.bind(this));
+      }
+
+      _onLanguageChanged(language) {
+        if (language) {
+          let url = this.resolveUrl(`locales/${language}.json`, `${window.location.origin}`);
+          this.loadResources(url, language, true);
+        }
+      }
+
+      /**
+       * Loads locales file for internationalization.
+       */
+      _localesFileChanged() {
+        if (this.localesFile && this.localesFile.trim().length != 0) {
+          this.loadResources(this.resolveUrl(this.localesFile));
+        }
+      }
+
+      /**
+       * Resets the language without the region information. In the case the
+       * resources load failed because of a file not found this brings one more
+       * chance to find translations more suitable to the user.
+       */
+      _unregionalize() {
+        if (this.language.includes('-')) {
+          this.language = this.language.split('-')[0];
+        } else {
+          this.language = 'en';
+        }
+      }
+
+    };
+
+    Hostabee.ElementMixin = Polymer.dedupingMixin(ElementMixin);
+  })();
+</script>

--- a/hostabee-element.html
+++ b/hostabee-element.html
@@ -1,0 +1,35 @@
+<!--
+@license
+Copyright (c) 2019 Hostabee SAS.
+This program is available under Apache License Version 2.0.
+-->
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="./hostabee-element-mixin.html">
+
+<script>
+  (function() {
+    'use strict';
+
+    /**
+     * @namespace Hostabee
+     */
+    window.Hostabee = window.Hostabee || {};
+
+    /**
+     * @customElement
+     * @polymer
+     * @memberof Hostabee
+     * @constructor
+     * @implements {Hostabee.ElementMixin}
+     */
+    const Element = Hostabee.ElementMixin(Polymer.Element);
+    window.customElements.define(Element.is, Element);
+
+    /**
+     * @memberof Hostabee
+     * @implements {Hostabee.ElementMixin}
+     * @extends {HTMLElement}
+     */
+    Hostabee.Element = Element;
+  })();
+</script>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,13 @@
+{
+  "ERROR_at_least_20_chars": "At least 20 chars",
+  "LABEL_edit_your_comment": "Edit your comment",
+  "PLACEHOLDER_write_a_comment": "Write a comment...",
+  "anonymous": "{capitalize, select, yes {A} other {a}}nonymous",
+  "cancel": "cancel",
+  "delete": "delete",
+  "edit": "edit",
+  "modified": "modified",
+  "read_more": "read more",
+  "save": "save",
+  "show_less": "show less"
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,13 @@
+{
+  "ERROR_at_least_20_chars": "Minimum de 20 caractères",
+  "LABEL_edit_your_comment": "Modifier votre commentaire",
+  "PLACEHOLDER_write_a_comment": "Écrire un commentaire...",
+  "anonymous": "{capitalize, select, yes {A} other {a}}nonyme",
+  "cancel": "annuler",
+  "delete": "supprimer",
+  "edit": "modifier",
+  "modified": "modifié",
+  "read_more": "lire plus",
+  "save": "enregistrer",
+  "show_less": "montrer moins"
+}

--- a/test/hostabee-comment-create-form_test.html
+++ b/test/hostabee-comment-create-form_test.html
@@ -73,6 +73,79 @@
         });
       });
     });
+
+    describe('i18n', function() {
+      let element;
+
+      beforeEach(function() {
+        element = fixture('BasicTestFixture');
+        element.buttonsShown = true;
+      });
+
+      it('should support English', function(done) {
+        element.language = 'en';
+        flush(function() {
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            let textArea = element.shadowRoot.querySelector('vaadin-text-area');
+            expect(textArea.placeholder).to.be.equal('Write a comment...');
+            expect(textArea.errorMessage).to.be.equal('At least 20 chars');
+            let actions = element.shadowRoot.querySelector('.actions');
+            expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
+            expect(actions.children[1].innerText.trim()).to.be.equal('Save');
+            done();
+          }, 100);
+        });
+      });
+
+      it('should support French', function(done) {
+        flush(function() {
+          element.language = 'fr';
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            let textArea = element.shadowRoot.querySelector('vaadin-text-area');
+            expect(textArea.placeholder).to.be.equal('Écrire un commentaire...');
+            expect(textArea.errorMessage).to.be.equal('Minimum de 20 caractères');
+            let actions = element.shadowRoot.querySelector('.actions');
+            expect(actions.children[0].innerText.trim()).to.be.equal('Annuler');
+            expect(actions.children[1].innerText.trim()).to.be.equal('Enregistrer');
+            done();
+          }, 100);
+        });
+      });
+
+      it('should fallback to English if locales not found for the given language', function(done) {
+        element.language = 'de';
+        flush(function() {
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            expect(element.language).to.be.equal('en');
+            done();
+          }, 100);
+        });
+      });
+
+      it('should allow to specify a custom locales file', function(done) {
+        element.language = 'en';
+        element.localesFile = 'test/my-locales.json';
+        flush(function() {
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            let textArea = element.shadowRoot.querySelector('vaadin-text-area');
+            expect(textArea.errorMessage).to.be.equal('20 chars min.');
+            let actions = element.shadowRoot.querySelector('.actions');
+            expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
+            expect(actions.children[1].innerText.trim()).to.be.equal('Confirm');
+            done();
+          }, 100);
+        });
+      });
+
+    });
   </script>
 
 </body>

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -33,6 +33,7 @@
 
       before(function() {
         element = fixture('BasicTestFixture');
+        element.language = 'en';
       });
 
       it('should be instantiable with default properties', function() {
@@ -183,6 +184,94 @@
         element.edit();
         expect(element.editing).to.be.false;
       });
+    });
+
+    describe('i18n', function() {
+      let element;
+
+      beforeEach(function() {
+        element = fixture('BasicTestFixture');
+      });
+
+      it('should support English', function(done) {
+        element.language = 'en';
+        element.edit(); // Set to edit mode to check form texts.
+        flush(function() {
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modified:');
+            let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
+            expect(menuOptions[0].innerText.trim()).to.be.equal('edit');
+            expect(menuOptions[1].innerText.trim()).to.be.equal('delete');
+            let textArea = element.shadowRoot.querySelector('vaadin-text-area');
+            expect(textArea.label).to.be.equal('Edit your comment');
+            expect(textArea.errorMessage).to.be.equal('At least 20 chars');
+            let actions = element.shadowRoot.querySelector('.actions');
+            expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
+            expect(actions.children[1].innerText.trim()).to.be.equal('Save');
+            done();
+          }, 100);
+        });
+      });
+
+      it('should support French', function(done) {
+        element.edit(); // Set to edit mode to check form texts.
+        flush(function() {
+          element.language = 'fr';
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modifié:');
+            let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
+            expect(menuOptions[0].innerText.trim()).to.be.equal('modifier');
+            expect(menuOptions[1].innerText.trim()).to.be.equal('supprimer');
+            let textArea = element.shadowRoot.querySelector('vaadin-text-area');
+            expect(textArea.label).to.be.equal('Modifier votre commentaire');
+            expect(textArea.errorMessage).to.be.equal('Minimum de 20 caractères');
+            let actions = element.shadowRoot.querySelector('.actions');
+            expect(actions.children[0].innerText.trim()).to.be.equal('Annuler');
+            expect(actions.children[1].innerText.trim()).to.be.equal('Enregistrer');
+            done();
+          }, 100);
+        });
+      });
+
+      it('should fallback to English if locales not found for the given language', function(done) {
+        element.language = 'de';
+        flush(function() {
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            expect(element.language).to.be.equal('en');
+            done();
+          }, 100);
+        });
+      });
+
+      it('should be able to use a custom locales file', function(done) {
+        element.edit(); // Set to edit mode to check form texts.
+        element.language = 'en';
+        element.localesFile = 'test/my-locales.json';
+        flush(function() {
+          // Add a delay for Firefox because it seems to need more time to
+          // re-localize texts.
+          setTimeout(() => {
+            expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modified:');
+            let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
+            expect(menuOptions[0].innerText.trim()).to.be.equal('modify');
+            expect(menuOptions[1].innerText.trim()).to.be.equal('destroy');
+            let textArea = element.shadowRoot.querySelector('vaadin-text-area');
+            expect(textArea.label).to.be.equal('Edit the comment');
+            expect(textArea.errorMessage).to.be.equal('20 chars min.');
+            let actions = element.shadowRoot.querySelector('.actions');
+            expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
+            expect(actions.children[1].innerText.trim()).to.be.equal('Confirm');
+            done();
+          }, 100);
+        });
+      });
+
     });
   </script>
 

--- a/test/my-locales.json
+++ b/test/my-locales.json
@@ -1,0 +1,14 @@
+{
+  "en": {
+    "ERROR_at_least_20_chars": "20 chars min.",
+    "LABEL_edit_your_comment": "Edit the comment",
+    "anonymous": "",
+    "cancel": "cancel",
+    "delete": "destroy",
+    "edit": "modify",
+    "modified": "modified",
+    "read_more": "show more",
+    "save": "confirm",
+    "show_less": "show less"
+  }
+}


### PR DESCRIPTION
Before this commit the elements were only available in English. Now they
implement a behavior to localize their texts. They natively support
English and French. Users can also provide external file with custom
translations.