### PR TITLE
fix(comment): shorten function

### DIFF
--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -372,7 +372,9 @@ This program is available under Apache License Version 2.0.
        * @return {String} the text shorten.
        */
       shorten(text) {
-        return this.isShort ? text.trim() : text.slice(0, this.maxLengthBeforeCollapse).trim() + '...';
+        if (text) {
+          return this.isShort ? text.trim() : text.slice(0, this.maxLengthBeforeCollapse).trim() + '...';
+        }
       }
 
       /**


### PR DESCRIPTION
This commit avoids to try trim a variable which is undefined. This
situation happens when users and comments are provided asynchronously to
the `hostabee-comment-flow`.

Fixes #12