### PR TITLE
fix(i18n): translate "read more" button first render

### DIFF
--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -270,7 +270,7 @@ This program is available under Apache License Version 2.0.
           },
           _toggleButtonText: {
             type: String,
-            computed: '__computeToggleButtonText(opened, language)',
+            computed: '__computeToggleButtonText(opened, resources)',
           },
         };
       }

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -225,9 +225,6 @@
 
       it('should support French', function(done) {
         element.addEventListener('app-localize-resources-loaded', function() {
-          console.log('element.language :', element.language);
-          console.log('element.resources :', element.resources);
-          console.log(element.localize('read_more'));
           setTimeout(() => {
             expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modifié:');
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -225,6 +225,9 @@
 
       it('should support French', function(done) {
         element.addEventListener('app-localize-resources-loaded', function() {
+          console.log('element.language :', element.language);
+          console.log('element.resources :', element.resources);
+          console.log(element.localize('read_more'));
           setTimeout(() => {
             expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modifié:');
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');


### PR DESCRIPTION
Before this commit the "read more" button was not translated at the
first render. The reason was because the resources accorded to the new
language set were not yet loaded. Now the button text is recomputed when
the resources are ready (and change).

Fixes #14