### PR TITLE
feat(comment-flow): allow only author to edit comment

### DIFF
--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -26,7 +26,7 @@ This program is available under Apache License Version 2.0.
     </style>
     <div class="comments-container">
       <template is="dom-repeat" items="[[_comments]]" as="comment" restamp>
-        <hostabee-comment item="[[comment]]" read-only=[[readOnly]] language="{{language}}" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
+        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="{{language}}" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
       </template>
     </div>
     <template is="dom-if" if="[[!readOnly]]" restamp>
@@ -229,6 +229,23 @@ This program is available under Apache License Version 2.0.
           return this._users.find((u) => u.id == user) || user;
         }
         return user;
+      }
+
+      /**
+       * Tells if a comment should be editable or not. It depends if the comment
+       * flow is in read only mode or not and if an author was defined. When the
+       * comment flow has the read only mode turned off and an author is defined,
+       * the user can only edit/delete the comments they wrote.
+       *
+       * @param {Object} comment The comment to check is editable or not.
+       * @return {Boolean} true if the comment flow has read only mode turned off
+       * and the author is defined and is the writer of the comment.
+       */
+      _isCommentEditable(comment) {
+        if (this.readOnly || !comment.author) {
+          return false;
+        }
+        return this.author && this.author.id == comment.author.id;
       }
 
       /**

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -122,6 +122,58 @@
         };
         element.addEventListener('form-changed', asyncAssert);
       });
+
+      it('should allow to edit comments only owned by the author if set', function(done) {
+        element.comments = [{
+          author: {
+            id: 1,
+            name: 'John Doe',
+          },
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now()
+        }, {
+          author: {
+            id: 2,
+            name: 'Jane Doe',
+          },
+          content: 'Consectetur adipiscing elit.',
+          created: Date.now()
+        }, {
+          content: 'Consectetur adipiscing elit.',
+          created: Date.now()
+        }];
+        element.author = {
+          id: 1,
+          name: 'John Doe',
+        };
+        flush(function() {
+          let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+          expect(comments[0].readOnly).to.be.false;
+          expect(comments[1].readOnly).to.be.true;
+          expect(comments[2].readOnly).to.be.true;
+          done();
+        });
+      });
+
+      it('should not allow to edit comments when author is not set', function(done) {
+        element.comments = [{
+          author: {
+            id: 1,
+            name: 'John Doe',
+          },
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now()
+        }, {
+          content: 'Consectetur adipiscing elit.',
+          created: Date.now()
+        }];
+        flush(function() {
+          let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+          expect(comments[0].readOnly).to.be.true;
+          expect(comments[1].readOnly).to.be.true;
+          done();
+        });
+      });
     });
 
     describe('ReadOnly', function() {


### PR DESCRIPTION
By default everyone can edit and delete comments from the
hostabee-comment-flow. The user has to implement its own access rules.
With this commit, when an author is defined, the hostabee-commment-flow
does not allow to edit or delete comment not written by the author.

Closes #16