### PR TITLE
Make hostabee-comment-flow pass i18n settings to children

### DIFF
--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -26,12 +26,12 @@ This program is available under Apache License Version 2.0.
     </style>
     <div class="comments-container">
       <template is="dom-repeat" items="[[_comments]]" as="comment" restamp>
-        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="{{language}}" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
+        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="{{language}}" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
       </template>
     </div>
     <template is="dom-if" if="[[!readOnly]]" restamp>
       <slot id="form" name="form">
-        <hostabee-comment-create-form author="[[author]]" language="{{language}}" on-comment-added="_retargetEvent"></hostabee-comment-create-form>
+        <hostabee-comment-create-form author="[[author]]" language="{{language}}" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-added="_retargetEvent"></hostabee-comment-create-form>
       </slot>
     </template>
     <slot id="mapper" name="mapper"></slot>

--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -26,12 +26,12 @@ This program is available under Apache License Version 2.0.
     </style>
     <div class="comments-container">
       <template is="dom-repeat" items="[[_comments]]" as="comment" restamp>
-        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="{{language}}" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
+        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
       </template>
     </div>
     <template is="dom-if" if="[[!readOnly]]" restamp>
       <slot id="form" name="form">
-        <hostabee-comment-create-form author="[[author]]" language="{{language}}" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-added="_retargetEvent"></hostabee-comment-create-form>
+        <hostabee-comment-create-form author="[[author]]" language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-added="_retargetEvent"></hostabee-comment-create-form>
       </slot>
     </template>
     <slot id="mapper" name="mapper"></slot>

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -44,6 +44,12 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="I18nTestFixture">
+    <template>
+      <hostabee-comment-flow></hostabee-comment-flow>
+    </template>
+  </test-fixture>
+
   <script>
     describe('Basic', function() {
       let element;
@@ -387,6 +393,98 @@
           done();
         };
         element.addEventListener('mapper-changed', asyncAssert);
+      });
+    });
+
+    describe('i18n', function() {
+      let element;
+
+      beforeEach(function() {
+        element = fixture('I18nTestFixture');
+      });
+
+      it('should support English', function(done) {
+        element.comments = [{
+          id: 1,
+          text: 'Cum sociis natoque penatibus et magnis.',
+        }, {
+          id: 2,
+          text: 'Cum sociis natoque penatibus magnis?',
+        }];
+        element.addEventListener('app-localize-resources-loaded', function() {
+          setTimeout(function() {
+            let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+            comments.forEach(comment => expect(comment.language).to.be.equal('en'));
+            expect(element.shadowRoot.querySelector('hostabee-comment-create-form').language).to.be.equal('en');
+            done();
+          }, 100);
+        }, {
+          once: true,
+        });
+        flush(function() {
+          element.language = 'en';
+        });
+      });
+
+      it('should support French', function(done) {
+        element.comments = [{
+          id: 1,
+          text: 'Cum sociis natoque penatibus et magnis.',
+        }, {
+          id: 2,
+          text: 'Cum sociis natoque penatibus magnis?',
+        }];
+        element.addEventListener('app-localize-resources-loaded', function() {
+          setTimeout(function() {
+            let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+            comments.forEach(comment => expect(comment.language).to.be.equal('fr'));
+            expect(element.shadowRoot.querySelector('hostabee-comment-create-form').language).to.be.equal('fr');
+            done();
+          }, 100);
+        }, {
+          once: true,
+        });
+        flush(function() {
+          element.language = 'fr';
+        });
+      });
+
+      it('should propagate locales file path to children', function(done) {
+        element.comments = [{
+          id: 1,
+          text: 'Cum sociis natoque penatibus et magnis.',
+        }, {
+          id: 2,
+          text: 'Cum sociis natoque penatibus magnis?',
+        }];
+        element.localesFile = 'test/my-locales.json';
+        flush(function() {
+          expect(element.localesFile).to.be.equal('test/my-locales.json');
+          let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+          comments.forEach(comment => expect(comment.localesFile).to.be.equal('test/my-locales.json'));
+          let form = element.shadowRoot.querySelector('hostabee-comment-create-form');
+          expect(form.localesFile).to.be.equal('test/my-locales.json');
+          done();
+        });
+      });
+
+      it('should propagate locales folder path to children', function(done) {
+        element.comments = [{
+          id: 1,
+          text: 'Cum sociis natoque penatibus et magnis.',
+        }, {
+          id: 2,
+          text: 'Cum sociis natoque penatibus magnis?',
+        }];
+        flush(function() {
+          element.localesFolder = '../my_locales';
+          expect(element.localesFolder).to.be.equal('../my_locales');
+          let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+          comments.forEach(comment => expect(comment.localesFolder).to.be.equal('../my_locales'));
+          let form = element.shadowRoot.querySelector('hostabee-comment-create-form');
+          expect(form.localesFolder).to.be.equal('../my_locales');
+          done();
+        });
       });
     });
   </script>


### PR DESCRIPTION
Before this PR the comment flow was not passing
locales folder/file path to its children so one
child was able to load another file and overwrite
the dictionary loaded by the parent.