### PR TITLE
feat(comment): allow to toggle creation and update dates

### DIFF
--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -53,8 +53,16 @@ This program is available under Apache License Version 2.0.
         font-size: 0.95em;
       }
 
-      .summary__date>i {
+      .summary__date>span {
         text-transform: capitalize;
+      }
+
+      .summary__date>span:hover {
+        cursor: pointer;
+      }
+
+      .summary__date>span[updated] {
+        font-style: italic;
       }
 
       .content {
@@ -101,9 +109,8 @@ This program is available under Apache License Version 2.0.
       <hostabee-profile-picture src="[[item.author]]"></hostabee-profile-picture>
       <div class="summary">
         <span class="summary__author-name">[[authorName]]</span>
-        <div class="summary__date">
-          <i hidden$="[[!item.updated]]">[[localize('modified')]]:</i>
-          <span>[[getDateLastEdit(item)]]</span>
+        <div class="summary__date" on-click="toggleDates">
+          <span></span>
         </div>
       </div>
       <span class="flex"></span>
@@ -276,6 +283,16 @@ This program is available under Apache License Version 2.0.
       }
 
       /**
+       * Array of strings describing multi-property observer methods and their
+       * dependant properties
+       */
+      static get observers() {
+        return [
+          'toggleDates(item, resources)',
+        ];
+      }
+
+      /**
        * Gets the date of last edit of a comment. Returns the `updated` or the
        * `created` date formatted. You'll get a relative time (e.g. 2 hours ago)
        * if MomentJs is imported in your app.
@@ -355,6 +372,7 @@ This program is available under Apache License Version 2.0.
           composed: true
         }));
         this._setEditing(false);
+        this.toggleDates();
       }
 
       /**
@@ -374,6 +392,25 @@ This program is available under Apache License Version 2.0.
       shorten(text) {
         if (text) {
           return this.isShort ? text.trim() : text.slice(0, this.maxLengthBeforeCollapse).trim() + '...';
+        }
+      }
+
+      /**
+       * Switches between creation and last update dates. If the creation date
+       * is displayed a call to this method will display the last update date if
+       * the comment has been updated. And vis versa.
+       */
+      toggleDates() {
+        if (!this.item) {
+          return;
+        }
+        let span = this.shadowRoot.querySelector('.summary__date>span');
+        if (!span.hasAttribute('updated') && this.item.updated) {
+          span.innerText = this.localize('modified') + this._formatDate(this.item.updated);
+          span.toggleAttribute('updated', true);
+        } else {
+          span.innerText = this.localize('created') + this._formatDate(this.item.created);
+          span.toggleAttribute('updated', false);
         }
       }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -4,9 +4,10 @@
   "PLACEHOLDER_write_a_comment": "Write a comment...",
   "anonymous": "{capitalize, select, yes {A} other {a}}nonymous",
   "cancel": "cancel",
+  "created": "created: ",
   "delete": "delete",
   "edit": "edit",
-  "modified": "modified",
+  "modified": "modified: ",
   "read_more": "read more",
   "save": "save",
   "show_less": "show less"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4,9 +4,10 @@
   "PLACEHOLDER_write_a_comment": "Écrire un commentaire...",
   "anonymous": "{capitalize, select, yes {A} other {a}}nonyme",
   "cancel": "annuler",
+  "created": "créé: ",
   "delete": "supprimer",
   "edit": "modifier",
-  "modified": "modifié",
+  "modified": "modifié: ",
   "read_more": "lire plus",
   "save": "enregistrer",
   "show_less": "montrer moins"

--- a/test/hostabee-comment-create-form_test.html
+++ b/test/hostabee-comment-create-form_test.html
@@ -122,18 +122,6 @@
         });
       });
 
-      it('should fallback to English if locales not found for the given language', function(done) {
-        element.language = 'de';
-        flush(function() {
-          // Add a delay for Firefox because it seems to need more time to
-          // re-localize texts.
-          setTimeout(() => {
-            expect(element.language).to.be.equal('en');
-            done();
-          }, 100);
-        });
-      });
-
       it('should allow to specify a custom locales file', function(done) {
         element.language = 'en';
         element.localesFile = 'test/my-locales.json';

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -154,6 +154,32 @@
           done();
         });
       });
+
+      it('should allow switching between creation date and update date when there is one', function(done) {
+        element.item = {
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now(),
+        };
+        element.addEventListener('comment-modified', function(event) {
+          element.item = event.detail; // Update element with new version of the comment
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('modified:');
+          span.click();
+          expect(span.innerText.toLowerCase()).to.includes('created:');
+          span.click();
+          expect(span.innerText.toLowerCase()).to.includes('modified:');
+          span.click();
+          expect(span.innerText.toLowerCase()).to.includes('created:');
+          done();
+        }, {
+          once: true,
+        });
+        element.edit();
+        flush(function() {
+          element.item.content = 'Lorem ipsum dolor sit amet.';
+          element.confirmEdit();
+        });
+      });
     });
 
     describe('ReadOnly', function() {
@@ -203,7 +229,6 @@
       it('should support English', function(done) {
         element.addEventListener('app-localize-resources-loaded', function() {
           setTimeout(function() {
-            expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modified:');
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
             expect(menuOptions[0].innerText.trim()).to.be.equal('edit');
             expect(menuOptions[1].innerText.trim()).to.be.equal('delete');
@@ -226,7 +251,6 @@
       it('should support French', function(done) {
         element.addEventListener('app-localize-resources-loaded', function() {
           setTimeout(() => {
-            expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modifié:');
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
             expect(menuOptions[0].innerText.trim()).to.be.equal('modifier');
             expect(menuOptions[1].innerText.trim()).to.be.equal('supprimer');
@@ -262,7 +286,6 @@
         element.language = 'en';
         flush(function() {
           element.addEventListener('app-localize-resources-loaded', function() {
-            expect(element.shadowRoot.querySelector('.summary__date > i').innerText).to.be.equal('Modified:');
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
             expect(menuOptions[0].innerText.trim()).to.be.equal('modify');
             expect(menuOptions[1].innerText.trim()).to.be.equal('destroy');

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -270,18 +270,6 @@
         });
       });
 
-      it('should fallback to English if locales not found for the given language', function(done) {
-        flush(function() {
-          element.addEventListener('app-localize-resources-loaded', function() {
-            expect(element.language).to.be.equal('en');
-            done();
-          }, {
-            once: true,
-          });
-          element.language = 'de';
-        });
-      });
-
       it('should be able to use a custom locales file', function(done) {
         element.language = 'en';
         flush(function() {


### PR DESCRIPTION
This commit offers the possibility to switch between the creation and
the last update dates (if the comment has been updated). Before this
commit, when a comment was updated users were not able to see the
creation date, never.