### PR TITLE
chore(build): unlock Firefox version for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - polymer install
 node_js: node
 addons:
-  firefox: '66.0'
+  firefox: latest
   chrome: stable
 script:
   - xvfb-run polymer test


### PR DESCRIPTION
The version used in unit tests of Firefox was locked due to
incompatibility (at least unusability) of the Geckodriver on
Travis CI. This commit unlocks it.