### PR TITLE
feat(comment): allow to disable relative time

### DIFF
--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -26,7 +26,7 @@ This program is available under Apache License Version 2.0.
     </style>
     <div class="comments-container">
       <template is="dom-repeat" items="[[_comments]]" as="comment" restamp>
-        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent"></hostabee-comment>
+        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent" no-relative-time="[[noRelativeTime]]"></hostabee-comment>
       </template>
     </div>
     <template is="dom-if" if="[[!readOnly]]" restamp>
@@ -157,6 +157,21 @@ This program is available under Apache License Version 2.0.
            */
           author: {
             type: Object,
+          },
+          /**
+           * Disables relative time. If MomentJs is imported in the app where
+           * this element is used, it uses relative times for creation and
+           * update dates. When this attribute is set to `true`, the element
+           * does not use relative time even if MomentJs is presents in the
+           * environment.
+           * 
+           * @type {Boolean}
+           * @default false
+           */
+          noRelativeTime: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: true,
           },
           localesFolder: {
             type: String,

--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -271,6 +271,21 @@ This program is available under Apache License Version 2.0.
             type: String,
             computed: '__computeAuthorName(item.author, resources)',
           },
+          /**
+           * Disables relative time. If MomentJs is imported in the app where
+           * this element is used, it uses relative times for creation and
+           * update dates. When this attribute is set to `true`, the element
+           * does not use relative time even if MomentJs is presents in the
+           * environment.
+           * 
+           * @type {Boolean}
+           * @default false
+           */
+          noRelativeTime: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: true,
+          },
           localesFolder: {
             type: String,
             value: 'locales',
@@ -288,7 +303,8 @@ This program is available under Apache License Version 2.0.
        */
       static get observers() {
         return [
-          'toggleDates(item, resources)',
+          'toggleDates(item)',
+          'refreshDate(resources, noRelativeTime)',
         ];
       }
 
@@ -372,7 +388,6 @@ This program is available under Apache License Version 2.0.
           composed: true
         }));
         this._setEditing(false);
-        this.toggleDates();
       }
 
       /**
@@ -406,12 +421,49 @@ This program is available under Apache License Version 2.0.
         }
         let span = this.shadowRoot.querySelector('.summary__date>span');
         if (!span.hasAttribute('updated') && this.item.updated) {
-          span.innerText = this.localize('modified') + this._formatDate(this.item.updated);
-          span.toggleAttribute('updated', true);
+          this._displayLastUpdateDate(span);
         } else {
-          span.innerText = this.localize('created') + this._formatDate(this.item.created);
-          span.toggleAttribute('updated', false);
+          this._displayCreationDate(span);
         }
+      }
+
+      /**
+       * Refreshes the date displayed under the author name. This method is
+       * auto matically called when language changes or relative time is
+       * enabled/disabled.
+       */
+      refreshDate() {
+        if (!this.item) {
+          return;
+        }
+        let span = this.shadowRoot.querySelector('.summary__date>span');
+        if (span.hasAttribute('updated') && this.item.updated) {
+          this._displayLastUpdateDate(span);
+        } else {
+          this._displayCreationDate(span);
+        }
+      }
+
+      /**
+       * Displays date of last update below comment author name.
+       * 
+       * @param {HTMLElement} span The span under the author name to be filled
+       * with the last udpate date.
+       */
+      _displayLastUpdateDate(span) {
+        span.innerText = this.localize('modified') + this._formatDate(this.item.updated);
+        span.toggleAttribute('updated', true);
+      }
+
+      /**
+       * Displays date of creation below comment author name.
+       * 
+       * @param {HTMLElement} span The span under the author name to be filled
+       * with the creation date.
+       */
+      _displayCreationDate(span) {
+        span.innerText = this.localize('created') + this._formatDate(this.item.created);
+        span.toggleAttribute('updated', false);
       }
 
       /**
@@ -429,7 +481,7 @@ This program is available under Apache License Version 2.0.
         if (time) {
           var timestamp = typeof time == 'object' ?
             (time.toMillis ? time.toMillis() : time.getTime()) : time;
-          if ('moment' in window) {
+          if (!this.noRelativeTime && 'moment' in window) {
             return moment(Number(timestamp)).fromNow();
           }
           var d = new Date(Number(timestamp));

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -50,6 +50,14 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="WithMomentJs">
+    <template>
+      <div>
+        <hostabee-comment-flow></hostabee-comment-flow>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     describe('Basic', function() {
       let element;
@@ -483,6 +491,54 @@
           comments.forEach(comment => expect(comment.localesFolder).to.be.equal('../my_locales'));
           let form = element.shadowRoot.querySelector('hostabee-comment-create-form');
           expect(form.localesFolder).to.be.equal('../my_locales');
+          done();
+        });
+      });
+    });
+
+    describe('With MomentJs loaded', function() {
+      let element;
+
+      before(function(done) {
+        // Load MomentJs
+        let script = document.createElement('script');
+        script.src = '../../../../bower_components/moment/min/moment.min.js';
+        script.onload = function() {
+          done();
+        };
+        document.head.appendChild(script);
+      });
+
+      beforeEach(function() {
+        element = fixture('WithMomentJs').querySelector('hostabee-comment-flow');
+      });
+
+      it('should display relative time by default', function(done) {
+        element.comments = [{
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now(),
+        }];
+        flush(function() {
+          expect('moment' in window).to.be.true;
+          let commentElement = element.shadowRoot.querySelector('hostabee-comment');
+          let span = commentElement.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('few seconds ago');
+          done();
+        });
+      });
+
+      it('should not use relative time if disabled', function(done) {
+        element.comments = [{
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: new Date(),
+        }];
+        element.noRelativeTime = true;
+        flush(function() {
+          expect('moment' in window).to.be.true;
+          let commentElement = element.shadowRoot.querySelector('hostabee-comment');
+          let span = commentElement.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.not.includes('few seconds ago');
+          expect(span.innerText.toLowerCase()).to.includes(element.comments[0].created.toLocaleTimeString());
           done();
         });
       });

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -538,7 +538,7 @@
           let commentElement = element.shadowRoot.querySelector('hostabee-comment');
           let span = commentElement.shadowRoot.querySelector('.summary__date>span');
           expect(span.innerText.toLowerCase()).to.not.includes('few seconds ago');
-          expect(span.innerText.toLowerCase()).to.includes(element.comments[0].created.toLocaleTimeString());
+          expect(span.innerText.toLowerCase()).to.includes(element.comments[0].created.toLocaleTimeString().toLowerCase());
           done();
         });
       });

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -33,6 +33,14 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="WithMomentJs">
+    <template>
+      <div>
+        <hostabee-comment></hostabee-comment>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     describe('Basic', function() {
       let element;
@@ -290,7 +298,49 @@
           element.localesFile = 'test/my-locales.json';
         });
       });
+    });
 
+    describe('With MomentJs loaded', function() {
+      let element;
+
+      before(function(done) {
+        element = fixture('WithMomentJs').querySelector('hostabee-comment');
+        // Load MomentJs
+        let script = document.createElement('script');
+        script.src = '../../../../bower_components/moment/min/moment.min.js';
+        script.onload = function() {
+          done();
+        };
+        document.head.appendChild(script);
+      });
+
+      it('should display relative time by default', function(done) {
+        element.item = {
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now(),
+        };
+        flush(function() {
+          expect('moment' in window).to.be.true;
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('few seconds ago');
+          done();
+        });
+      });
+
+      it('should not use relative time if disabled', function(done) {
+        element.item = {
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: new Date(),
+        };
+        element.noRelativeTime = true;
+        flush(function() {
+          expect('moment' in window).to.be.true;
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.not.includes('few seconds ago');
+          expect(span.innerText.toLowerCase()).to.includes(element.item.created.toLocaleTimeString());
+          done();
+        });
+      });
     });
   </script>
 

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -337,7 +337,7 @@
           expect('moment' in window).to.be.true;
           let span = element.shadowRoot.querySelector('.summary__date>span');
           expect(span.innerText.toLowerCase()).to.not.includes('few seconds ago');
-          expect(span.innerText.toLowerCase()).to.includes(element.item.created.toLocaleTimeString());
+          expect(span.innerText.toLowerCase()).to.includes(element.item.created.toLocaleTimeString().toLowerCase());
           done();
         });
       });


### PR DESCRIPTION
Before this commit users haven't the choice to use relative time in the
hostabee-comment-flow if they loaded MomentJs in their app. This commit
adds a new attribute to disable relative time even when MomentJs is
loaded.