### PR TITLE
fix(comment): displayed date below author name

### DIFF
--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -201,6 +201,7 @@ This program is available under Apache License Version 2.0.
            */
           item: {
             type: Object,
+            observer: '_itemChanged',
           },
           /**
            * Read only mode enabled. When the read only mode is enabled, the
@@ -299,7 +300,6 @@ This program is available under Apache License Version 2.0.
        */
       static get observers() {
         return [
-          'toggleDates(item)',
           'refreshDate(resources, noRelativeTime)',
         ];
       }
@@ -453,14 +453,37 @@ This program is available under Apache License Version 2.0.
       }
 
       /**
+       * Displays the creation date of the comment below the author name.
+       */
+      displayCreationDate() {
+        this._displayCreationDate(this.shadowRoot.querySelector('.summary__date>span'));
+      }
+
+      _itemChanged(newItem, oldItem) {
+        // Switch from creation date to udpate date if the previous version of
+        // the item did not have update date but the new one yes, or if there was
+        // no previous version of the item and the initial one has an update date.
+        if ((oldItem && !oldItem.updated) ||
+          (!oldItem && newItem && newItem.updated)) {
+          this.toggleDates();
+        } else if (!newItem) {
+          this.displayCreationDate();
+        } else {
+          this.refreshDate();
+        }
+      }
+
+      /**
        * Displays date of last update below comment author name.
        * 
        * @param {HTMLElement} span The span under the author name to be filled
        * with the last udpate date.
        */
       _displayLastUpdateDate(span) {
-        span.innerText = this.capitalize(this.localize('modified')) +
-          this._formatDate(this.item.updated);
+        if (this.item) {
+          span.innerText = this.capitalize(this.localize('modified')) +
+            this._formatDate(this.item.updated);
+        }
         span.toggleAttribute('updated', true);
       }
 
@@ -471,8 +494,10 @@ This program is available under Apache License Version 2.0.
        * with the creation date.
        */
       _displayCreationDate(span) {
-        span.innerText = this.capitalize(this.localize('created')) +
-          this._formatDate(this.item.created);
+        if (this.item) {
+          span.innerText = this.capitalize(this.localize('created')) +
+            this._formatDate(this.item.created);
+        }
         span.toggleAttribute('updated', false);
       }
 

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -50,10 +50,9 @@
         element.language = 'en';
       });
 
-      it('should be instantiable with default properties', function() {
-        expect(element.item).to.be.undefined;
-        expect(element.readOnly).to.be.false;
-      });
+      beforeEach(function() {
+        element.item = null;
+      })
 
       it('should not be able to confirm edit when not in edit mode', function(done) {
         const asyncAssert = function() {
@@ -184,6 +183,51 @@
         });
         element.edit();
         flush(function() {
+          element.item.content = 'Lorem ipsum dolor sit amet.';
+          element.confirmEdit();
+        });
+      });
+
+      it('should automatically switch from update date to creation date', function(done) {
+        element.item = {
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now(),
+        };
+        element.addEventListener('comment-modified', function(event) {
+          element.item = event.detail; // Update element with new version of the comment
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('modified:');
+          done();
+        }, {
+          once: true,
+        });
+        element.edit();
+        flush(function() {
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('created:');
+          element.item.content = 'Lorem ipsum dolor sit amet.';
+          element.confirmEdit();
+        });
+      });
+
+      it('should not automatically switch from update date to creation date', function(done) {
+        element.item = {
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          created: Date.now(),
+          updated: Date.now(),
+        };
+        element.addEventListener('comment-modified', function(event) {
+          element.item = event.detail; // Update element with new version of the comment
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('modified:');
+          done();
+        }, {
+          once: true,
+        });
+        element.edit();
+        flush(function() {
+          let span = element.shadowRoot.querySelector('.summary__date>span');
+          expect(span.innerText.toLowerCase()).to.includes('modified:');
           element.item.content = 'Lorem ipsum dolor sit amet.';
           element.confirmEdit();
         });


### PR DESCRIPTION
This commit ensures the date displayed below the author name is
automatically refreshed or switched to updated date when the comment
changes according to the previous state and the new version of the item.

Fixes #25