### PR TITLE
feat(validation): allow to change minimum length required

### DIFF
--- a/hostabee-comment-create-form.html
+++ b/hostabee-comment-create-form.html
@@ -62,7 +62,7 @@ This program is available under Apache License Version 2.0.
       <template is="dom-if" if="[[author]]">
         <hostabee-profile-picture src="[[author]]" size="38"></hostabee-profile-picture>
       </template>
-      <vaadin-text-area placeholder="[[localize('PLACEHOLDER_write_a_comment')]]" minlength="20" error-message="[[localize('ERROR_at_least_20_chars')]]" onkeydown="[[_handleKeyDown()]]" value="{{value}}" required></vaadin-text-area>
+      <vaadin-text-area placeholder="[[localize('PLACEHOLDER_write_a_comment')]]" minlength="[[minlength]]" error-message="[[localize('ERROR_minlength', 'count', minlength)]]" onkeydown="[[_handleKeyDown()]]" value="{{value}}" required></vaadin-text-area>
     </div>
 
     <template is="dom-if" if="[[actionButtonsVisible]]">
@@ -139,6 +139,17 @@ This program is available under Apache License Version 2.0.
             type: Boolean,
             value: false,
             readOnly: true,
+          },
+          /**
+           * Minimum number of characters (in Unicode code points) that the user
+           * can enter.
+           * 
+           * @type {Number}
+           * @default 20
+           */
+          minlength: {
+            type: Number,
+            value: 20,
           },
           /**
            * Value in the form input.

--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -26,12 +26,12 @@ This program is available under Apache License Version 2.0.
     </style>
     <div class="comments-container">
       <template is="dom-repeat" items="[[_comments]]" as="comment" restamp>
-        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent" no-relative-time="[[noRelativeTime]]"></hostabee-comment>
+        <hostabee-comment item="[[comment]]" read-only=[[!_isCommentEditable(comment)]] language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" minlength="[[minlength]]" on-comment-deleted="_retargetEvent" on-comment-modified="_retargetEvent" no-relative-time="[[noRelativeTime]]"></hostabee-comment>
       </template>
     </div>
     <template is="dom-if" if="[[!readOnly]]" restamp>
       <slot id="form" name="form">
-        <hostabee-comment-create-form author="[[author]]" language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" on-comment-added="_retargetEvent"></hostabee-comment-create-form>
+        <hostabee-comment-create-form author="[[author]]" language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" minlength="[[minlength]]" on-comment-added="_retargetEvent"></hostabee-comment-create-form>
       </slot>
     </template>
     <slot id="mapper" name="mapper"></slot>
@@ -113,6 +113,17 @@ This program is available under Apache License Version 2.0.
             type: Object,
             readOnly: true,
             notify: true,
+          },
+          /**
+           * Minimum number of characters (in Unicode code points) that the user
+           * can enter.
+           *
+           * @type {Number}
+           * @default 20
+           */
+          minlength: {
+            type: Number,
+            value: 20,
           },
           /**
            * List of users. It is OPTIONAL and will be used to retrieve comment

--- a/hostabee-comment.html
+++ b/hostabee-comment.html
@@ -139,7 +139,7 @@ This program is available under Apache License Version 2.0.
         </vaadin-button>
       </template>
       <template is="dom-if" if="[[editing]]">
-        <vaadin-text-area label="[[localize('LABEL_edit_your_comment')]]" minlength="20" error-message="[[localize('ERROR_at_least_20_chars')]]" value="[[item.content]]" onkeydown="[[_handleKeyDown()]]" autofocus required></vaadin-text-area>
+        <vaadin-text-area label="[[localize('LABEL_edit_your_comment')]]" minlength="[[minlength]]" error-message="[[localize('ERROR_minlength', 'count', minlength)]]" value="[[item.content]]" onkeydown="[[_handleKeyDown()]]" autofocus required></vaadin-text-area>
         <div class="actions">
           <vaadin-button theme="small" on-tap="cancelEdit">[[localize('cancel')]]</vaadin-button>
           <vaadin-button theme="primary small" on-tap="confirmEdit">[[localize('save')]]</vaadin-button>
@@ -237,6 +237,17 @@ This program is available under Apache License Version 2.0.
           maxLengthBeforeCollapse: {
             type: Number,
             value: 150,
+          },
+          /**
+           * Minimum number of characters (in Unicode code points) that the user
+           * can enter.
+           *
+           * @type {Number}
+           * @default 20
+           */
+          minlength: {
+            type: Number,
+            value: 20,
           },
           /**
            * Is the comment opened? When the comment is under the max length

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "ERROR_at_least_20_chars": "At least 20 chars",
+  "ERROR_minlength": "At least {count} chars",
   "LABEL_edit_your_comment": "Edit your comment",
   "PLACEHOLDER_write_a_comment": "Write a comment...",
   "anonymous": "{capitalize, select, yes {A} other {a}}nonymous",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,5 +1,5 @@
 {
-  "ERROR_at_least_20_chars": "Minimum de 20 caractères",
+  "ERROR_minlength": "Minimum de {count} caractères",
   "LABEL_edit_your_comment": "Modifier votre commentaire",
   "PLACEHOLDER_write_a_comment": "Écrire un commentaire...",
   "anonymous": "{capitalize, select, yes {A} other {a}}nonyme",

--- a/test/hostabee-comment-create-form_test.html
+++ b/test/hostabee-comment-create-form_test.html
@@ -78,6 +78,19 @@
           done();
         });
       });
+
+      it('should propagate minimum length required to inner text area', function(done) {
+        // Unfortunately, considering the issue https://github.com/vaadin/vaadin-text-field/issues/182
+        // we can't programmatically test validation based on minlength requirement.
+        expect(element.minlength).to.be.equal(20);
+        flush(function() {
+          const textArea = element.shadowRoot.querySelector('vaadin-text-area');
+          expect(textArea.minlength).to.be.equal(20);
+          element.minlength = 10;
+          expect(textArea.minlength).to.be.equal(10);
+          done();
+        });
+      });
     });
 
     describe('i18n', function() {
@@ -135,7 +148,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
             expect(actions.children[1].innerText.trim()).to.be.equal('Confirm');
             done();
-          }, 100);
+          }, 150);
         });
       });
 

--- a/test/hostabee-comment-create-form_test.html
+++ b/test/hostabee-comment-create-form_test.html
@@ -114,7 +114,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
             expect(actions.children[1].innerText.trim()).to.be.equal('Save');
             done();
-          }, 100);
+          }, 150);
         });
       });
 
@@ -131,7 +131,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Annuler');
             expect(actions.children[1].innerText.trim()).to.be.equal('Enregistrer');
             done();
-          }, 100);
+          }, 150);
         });
       });
 

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -436,12 +436,12 @@
           text: 'Cum sociis natoque penatibus magnis?',
         }];
         element.addEventListener('app-localize-resources-loaded', function() {
-          setTimeout(function() {
+          flush(function() {
             let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
             comments.forEach(comment => expect(comment.language).to.be.equal('en'));
             expect(element.shadowRoot.querySelector('hostabee-comment-create-form').language).to.be.equal('en');
             done();
-          }, 150);
+          });
         }, {
           once: true,
         });
@@ -459,12 +459,12 @@
           text: 'Cum sociis natoque penatibus magnis?',
         }];
         element.addEventListener('app-localize-resources-loaded', function() {
-          setTimeout(function() {
+          flush(function() {
             let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
             comments.forEach(comment => expect(comment.language).to.be.equal('fr'));
             expect(element.shadowRoot.querySelector('hostabee-comment-create-form').language).to.be.equal('fr');
             done();
-          }, 150);
+          });
         }, {
           once: true,
         });

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -188,6 +188,22 @@
           done();
         });
       });
+
+      it('should propagate minimum length required to inner comments and form', function(done) {
+        // Unfortunately, considering the issue https://github.com/vaadin/vaadin-text-field/issues/182
+        // we can't programmatically test validation based on minlength requirement.
+        expect(element.minlength).to.be.equal(20);
+        flush(function() {
+          let comments = element.shadowRoot.querySelectorAll('hostabee-comment');
+          comments.forEach((comment) => expect(comment.minlength).to.be.equal(20));
+          let form = element.shadowRoot.querySelector('hostabee-comment-create-form');
+          expect(form.minlength).to.be.equal(20);
+          element.minlength = 10;
+          comments.forEach((comment) => expect(comment.minlength).to.be.equal(10));
+          expect(form.minlength).to.be.equal(10);
+          done();
+        });
+      });
     });
 
     describe('ReadOnly', function() {

--- a/test/hostabee-comment-flow_test.html
+++ b/test/hostabee-comment-flow_test.html
@@ -441,7 +441,7 @@
             comments.forEach(comment => expect(comment.language).to.be.equal('en'));
             expect(element.shadowRoot.querySelector('hostabee-comment-create-form').language).to.be.equal('en');
             done();
-          }, 100);
+          }, 150);
         }, {
           once: true,
         });
@@ -464,7 +464,7 @@
             comments.forEach(comment => expect(comment.language).to.be.equal('fr'));
             expect(element.shadowRoot.querySelector('hostabee-comment-create-form').language).to.be.equal('fr');
             done();
-          }, 100);
+          }, 150);
         }, {
           once: true,
         });

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -232,6 +232,20 @@
           element.confirmEdit();
         });
       });
+
+      it('should propagate minimum length required to inner text area', function(done) {
+        // Unfortunately, considering the issue https://github.com/vaadin/vaadin-text-field/issues/182
+        // we can't programmatically test validation based on minlength requirement.
+        expect(element.minlength).to.be.equal(20);
+        element.edit();
+        flush(function() {
+          const textArea = element.shadowRoot.querySelector('vaadin-text-area');
+          expect(textArea.minlength).to.be.equal(20);
+          element.minlength = 10;
+          expect(textArea.minlength).to.be.equal(10);
+          done();
+        });
+      });
     });
 
     describe('ReadOnly', function() {

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -309,9 +309,7 @@
         }, {
           once: true,
         });
-        flush(function() {
-          element.language = 'en';
-        });
+        element.language = 'en';
       });
 
       it('should support French', function(done) {
@@ -331,9 +329,7 @@
         }, {
           once: true,
         });
-        flush(function() {
-          element.language = 'fr';
-        });
+        element.language = 'fr';
       });
 
       it('should be able to use a custom locales file', function(done) {

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -305,7 +305,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
             expect(actions.children[1].innerText.trim()).to.be.equal('Save');
             done();
-          }, 100);
+          }, 150);
         }, {
           once: true,
         });
@@ -327,7 +327,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Annuler');
             expect(actions.children[1].innerText.trim()).to.be.equal('Enregistrer');
             done();
-          }, 100);
+          }, 150);
         }, {
           once: true,
         });

--- a/test/hostabee-comment_test.html
+++ b/test/hostabee-comment_test.html
@@ -294,7 +294,7 @@
 
       it('should support English', function(done) {
         element.addEventListener('app-localize-resources-loaded', function() {
-          setTimeout(function() {
+          flush(function() {
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
             expect(menuOptions[0].innerText.trim()).to.be.equal('edit');
             expect(menuOptions[1].innerText.trim()).to.be.equal('delete');
@@ -305,7 +305,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Cancel');
             expect(actions.children[1].innerText.trim()).to.be.equal('Save');
             done();
-          }, 150);
+          });
         }, {
           once: true,
         });
@@ -316,7 +316,7 @@
 
       it('should support French', function(done) {
         element.addEventListener('app-localize-resources-loaded', function() {
-          setTimeout(() => {
+          flush(function() {
             let menuOptions = element.shadowRoot.querySelectorAll('.menu-item');
             expect(menuOptions[0].innerText.trim()).to.be.equal('modifier');
             expect(menuOptions[1].innerText.trim()).to.be.equal('supprimer');
@@ -327,7 +327,7 @@
             expect(actions.children[0].innerText.trim()).to.be.equal('Annuler');
             expect(actions.children[1].innerText.trim()).to.be.equal('Enregistrer');
             done();
-          }, 150);
+          });
         }, {
           once: true,
         });

--- a/test/index.html
+++ b/test/index.html
@@ -13,9 +13,9 @@
   <script>
     // Load and run all tests (.html, .js):
     WCT.loadSuites([
-      'hostabee-comment-flow_test.html',
       'hostabee-comment_test.html',
       'hostabee-comment-create-form_test.html',
+      'hostabee-comment-flow_test.html',
     ]);
   </script>
 

--- a/test/my-locales.json
+++ b/test/my-locales.json
@@ -1,6 +1,6 @@
 {
   "en": {
-    "ERROR_at_least_20_chars": "20 chars min.",
+    "ERROR_minlength": "{count} chars min.",
     "LABEL_edit_your_comment": "Edit the comment",
     "anonymous": "",
     "cancel": "cancel",


### PR DESCRIPTION
This commit exposes the `minlength` attribute to allow users to set
minimum length required for a valid comment. Default value stays 20
chars. Be careful if you had custom locales file. An entry was changed.