### PR TITLE
feat(connector): add Firebase connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Once installed, import it in your application:
 
 3. When in the `hostabee-comment-flow` directory, run `npm install` and then `bower install` to install dependencies.
 
+    * [OPTIONAL] If you want to run tests or demo of the element involving the `hostabee-comment-flow-firebase-connector` you have to provide the configuration of your application in the _"test/firebase-config.js"_ and _"demo/firebase-config.js"_ files.
+
 4. Run `npm start`, browser will automatically open the component API documentation.
 
 5. You can also open demo or in-browser tests by adding **demo** or **test** to the URL, for example:

--- a/demo/firebase-config.js
+++ b/demo/firebase-config.js
@@ -1,0 +1,10 @@
+// Put the configuration of the app you want to use for running demo.
+// Required only for demo with Firebase connector.
+(function() {
+  window.HCF = window.HCF || {};
+  // HCF.firebaseConfig = {
+  //   apiKey: "AIza...",
+  //   authDomain: "YOU_APP.firebaseapp.com",
+  //   projectId: "YOU_APP",
+  // };
+})();

--- a/demo/hostabee-comment-flow-firebase-connector/basic.html
+++ b/demo/hostabee-comment-flow-firebase-connector/basic.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>hostabee-comment-flow-firebase-connector demo</title>
+
+  <script src="../../../webcomponentsjs/webcomponents-loader.js"></script>
+
+  <link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+  <link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../../polymer/lib/elements/dom-bind.html">
+  <link rel="import" href="../../hostabee-comment-flow.html">
+  <link rel="import" href="../../hostabee-comment-flow-firebase-connector.html">
+
+  <custom-style>
+    <style is="custom-style" include="demo-pages-shared-styles">
+    </style>
+  </custom-style>
+
+  <script src="https://www.gstatic.com/firebasejs/5.9.0/firebase.js"></script>
+  <script src="./../firebase-config.js"></script>
+  <script src="./../users.js"></script>
+  <script src="./../comments.js"></script>
+</head>
+
+<body>
+  <div class="vertical-section-container centered">
+    <h3>Basic hostabee-comment-flow-firebase-connector demo</h3>
+    <demo-snippet>
+      <template>
+        <dom-bind>
+          <template>
+            <div style="height:400px;">
+              <hostabee-comment-flow-firebase-connector id="connector">
+                <hostabee-comment-flow slot="flow"></hostabee-comment-flow>
+              </hostabee-comment-flow-firebase-connector>
+            </div>
+            <script>
+              firebase.initializeApp(HCF.firebaseConfig);
+              const connector = document.querySelector('#connector');
+              connector.app = firebase;
+              connector.addEventListener('users-changed', function(event) {
+                let users = event.detail.value;
+                if (users.length > 0) {
+                  connector.flow.author = users[0];
+                }
+              });
+              connector.usersCollection = 'users';
+            </script>
+          </template>
+        </dom-bind>
+      </template>
+    </demo-snippet>
+  </div>
+</body>
+
+</html>

--- a/hostabee-comment-flow-firebase-connector.html
+++ b/hostabee-comment-flow-firebase-connector.html
@@ -1,0 +1,473 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/utils/debounce.html">
+<link rel="import" href="../polymer/lib/utils/flattened-nodes-observer.html">
+
+<dom-module id="hostabee-comment-flow-firebase-connector">
+  <template>
+    <slot name="flow"></slot>
+  </template>
+  <script>
+    /**
+     * `hostabee-comment-flow-firebase-connector`
+     * 
+     * A connector to Firebase. It allows to easily connect the comment flow to
+     * a Firebase app and interact with it.
+     *
+     * @summary A Firebase connector.
+     * @customElement
+     * @polymer
+     * @extends {Polymer.Element}
+     * @demo demo/hostabee-comment-flow-firebase-connector/basic.html Basic
+     */
+    class HostabeeCommentFlowFirebaseConnector extends Polymer.Element {
+
+      static get is() {
+        return 'hostabee-comment-flow-firebase-connector';
+      }
+
+      /**
+       * Object describing property-related metadata used by Polymer features
+       */
+      static get properties() {
+        return {
+          /**
+           * Firebase app. It can be a Firebase app instance or simply it's name.
+           * In the 2nd case, the app must be initialized in the app before using
+           * the connector.
+           * 
+           * @type {Object|String}
+           */
+          app: {
+            type: Object,
+          },
+          /**
+           * Query filter limit.
+           * 
+           * @type {Number}
+           */
+          limit: {
+            type: Number,
+            value: 0,
+          },
+          /**
+           * Query filter orderBy. You can specify the order direction simply by
+           * adding "asc" or "desc" after the property name. For example, you can
+           * set the `orderBy` property to "name asc" or "created desc". By
+           * default the order is ascending.
+           * 
+           * @type {String}
+           */
+          orderBy: {
+            type: String,
+          },
+          /**
+           * Comment collection name.
+           * 
+           * @type {String}
+           */
+          commentsCollection: {
+            type: String,
+            value: 'comments',
+          },
+          /**
+           * User collection name.
+           * 
+           * @type {String}
+           */
+          usersCollection: {
+            type: String,
+          },
+          /**
+           * Result of the query that fetches the comments.
+           * 
+           * @type {Array}
+           */
+          comments: {
+            type: Array,
+            value: [],
+            readOnly: true,
+            notify: true,
+          },
+          /**
+           * Result of the query that fetches the users.
+           * 
+           * @type {Array}
+           */
+          users: {
+            type: Array,
+            value: [],
+            readOnly: true,
+            notify: true,
+          },
+          /**
+           * Reference to the `hostabee-comment-flow` instance provided to the
+           * connector.
+           * 
+           * @type {Object}
+           */
+          flow: {
+            type: Object,
+            readOnly: true,
+            observer: '_flowChanged',
+          },
+          /**
+           * Reference to the Firebase app to be used by the connector.
+           */
+          _firebase: {
+            type: Object,
+            value: null,
+            computed: '_computeFirebase(app)',
+          },
+          _jobs: {
+            type: Object,
+            value: {},
+          },
+          _nodesObserver: Object,
+        };
+      }
+
+      /**
+       * Array of strings describing multi-property observer methods and their
+       * dependant properties
+       */
+      static get observers() {
+        return [
+          'fetchComments(_firebase, commentsCollection, limit, orderBy)',
+          'fetchUsers(_firebase, usersCollection)',
+          '__commentsChanged(comments.splices)',
+          '__usersChanged(users.splices)',
+        ];
+      }
+
+      /**
+       * Called every time the element is inserted into the DOM. Useful for 
+       * running setup code, such as fetching resources or rendering.
+       * Generally, you should try to delay work until this time.
+       */
+      connectedCallback() {
+        super.connectedCallback();
+        this._nodesObserver = new Polymer.FlattenedNodesObserver(this, (info) => {
+          var nodes = info.addedNodes.filter((n) => n.nodeType === Node.ELEMENT_NODE);
+          if (nodes.length > 0) {
+            this._setFlow(nodes[0]);
+          }
+        });
+      }
+
+      /**
+       * Called every time the element is removed from the DOM. Useful for 
+       * running clean up code (removing event listeners, etc.).
+       */
+      disconnectedCallback() {
+        super.disconnectedCallback();
+        this._nodesObserver.disconnect();
+      }
+
+      /**
+       * Fetches comments from Firebase. A Firebase app instance must have been
+       * provided and a `commentsCollection` name too.
+       */
+      fetchComments() {
+        if (!this._firebase) {
+          console.debug('No Firebase app provided.');
+          return;
+        }
+        if (!this.commentsCollection) {
+          console.debug('No comments collection name provided.');
+          return;
+        }
+        this.__debounce(() => {
+          let ref = this._firebase.firestore().collection(this.commentsCollection);
+          ref = this.__applyFilters(ref);
+          ref.get().then((querySnapshot) => {
+              this._setComments(querySnapshot.docs.map(this.__docToObject));
+              if (this.flow) {
+                this.flow.comments = Array.from(this.comments);
+              }
+            })
+            .catch(function(error) {
+              console.error(error);
+            });
+        }, 'fetch-comments');
+      }
+
+      /**
+       * Fetches users from Firebase. A Firebase app instance must have been
+       * provided and a `usersCollection` name too.
+       */
+      fetchUsers() {
+        if (!this._firebase) {
+          console.debug('No Firebase app provided.');
+          return;
+        }
+        if (!this.usersCollection) {
+          console.debug('No users collection name provided.');
+          return;
+        }
+        this.__debounce(() => {
+          this._firebase.firestore().collection(this.usersCollection).get()
+            .then((querySnapshot) => {
+              this._setUsers(querySnapshot.docs.map(this.__docToObject));
+              if (this.flow) {
+                this.flow.users = Array.from(this.users);
+              }
+            })
+            .catch(function(error) {
+              console.error(error);
+            });
+        }, 'fetch-users');
+      }
+
+      /**
+       * Sync Firebase connector and comment-flow list of comment.
+       */
+      __commentsChanged(changeRecord) {
+        if (changeRecord && this.flow) {
+          changeRecord.indexSplices.forEach((cr) => {
+            let updatedIds = [];
+            for (var i = 0; i < cr.addedCount; i++) {
+              const comment = cr.object[cr.index + i];
+              var index = this.flow.comments.findIndex((c) => c.doc_id == comment.doc_id);
+              if (index > -1) {
+                this.flow.splice('comments', index, 1, comment);
+                updatedIds.push(comment.doc_id);
+              } else {
+                this.flow.push('comments', comment);
+              }
+            }
+            cr.removed.forEach((comment) => {
+              if (!updatedIds.includes(comment.doc_id)) {
+                var index = this.flow.comments.findIndex((c) => c.doc_id == comment.doc_id);
+                this.flow.splice('comments', index, 1);
+              }
+            });
+          });
+        }
+      }
+
+      /**
+       * Sync Firebase connector and comment-flow list of user.
+       */
+      __usersChanged(changeRecord) {
+        if (changeRecord && this.flow) {
+          changeRecord.indexSplices.forEach((cr) => {
+            cr.removed.forEach((user) => {
+              var index = this.flow.users.findIndex((u) => u.doc_id == user.doc_id);
+              this.flow.splice('users', index, 1);
+            });
+            for (var i = 0; i < cr.addedCount; i++) {
+              this.flow.push('users', cr.object[cr.index + i]);
+            }
+          });
+        }
+      }
+
+      /**
+       * Adds listeners on hostabee-comment-flow events (add, update, delete).
+       * Default events are overwritten by the connector ones.
+       */
+      _flowChanged() {
+        if (!this.flow) {
+          return;
+        }
+        if (!this._firebase) {
+          console.debug('Firebase not initialized.');
+          return;
+        }
+        // Add a comment to the Firebase collection then update local list.
+        this.flow.addEventListener('comment-added', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          delete event.detail.doc_id;
+          this.addComment(event.detail);
+        });
+        // Remove a comment to the Firebase collection then update local list.
+        this.flow.addEventListener('comment-deleted', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.deleteComment(event.detail);
+        });
+        // Update a comment to the Firebase collection then update local list.
+        this.flow.addEventListener('comment-modified', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.updateComment(event.detail);
+        });
+      }
+
+      /**
+       * Adds a comment into the designated collection in Firestore. Then
+       * dispatches an event the detail is a representation of the comment
+       * added. It's basically the document content plus a `doc_id` property
+       * which is the ID of the document created.
+       * 
+       * @param {Object} doc The comment to be inserted into the Firestore.
+       * The document is created into the `commentsCollection`.
+       */
+      addComment(doc) {
+        const comment = Object.assign({}, doc);
+        if (comment.author && typeof comment.author == 'object') {
+          delete comment.author.doc_id;
+        }
+        this._firebase.firestore().collection(this.commentsCollection)
+          .add(comment)
+          .then((docRef) => {
+            comment.doc_id = docRef.id;
+            this.push('comments', comment);
+            this.dispatchEvent(new CustomEvent('comment-added', {
+              bubbles: true,
+              composed: true,
+              detail: comment,
+            }));
+          })
+          .catch(function(error) {
+            console.error("Error adding document: ", error);
+          });
+      }
+
+      /**
+       * Deletes a comment from the designated collection in Firestore. Then
+       * dispatches an event the detail is a representation of the comment
+       * removed. It's basically the document content plus a `doc_id` property
+       * which is the ID of the document deleted.
+       * 
+       * @param {Object} doc The comment to be removed from the
+       * `commentsCollection` in Firestore.
+       */
+      deleteComment(doc) {
+        this._firebase.firestore().collection(this.commentsCollection)
+          .doc(doc.doc_id).delete()
+          .then(() => {
+            var index = this.comments.findIndex((c) => c.doc_id == doc.doc_id);
+            if (index > -1) {
+              this.splice('comments', index, 1);
+              this.dispatchEvent(new CustomEvent('comment-deleted', {
+                bubbles: true,
+                composed: true,
+                detail: doc,
+              }));
+            }
+          })
+          .catch(function(error) {
+            console.error("Error removing document: ", error);
+          });
+      }
+
+      /**
+       * Updates a comment of the designated collection in Firestore. Then
+       * dispatches an event the detail is a representation of the comment
+       * updated. It's basically the document content plus a `doc_id` property
+       * which is the ID of the document updated.
+       * 
+       * @param {Object} doc The comment to be updated in the
+       * `commentsCollection` in Firestore.
+       */
+      updateComment(doc) {
+        const comment = Object.assign({}, doc);
+        delete comment.doc_id;
+        this._firebase.firestore().collection(this.commentsCollection)
+          .doc(doc.doc_id).update(comment)
+          .then(() => {
+            var index = this.comments.findIndex((c) => c.doc_id == doc.doc_id);
+            if (index > -1) {
+              this.splice('comments', index, 1, doc);
+              this.dispatchEvent(new CustomEvent('comment-modified', {
+                bubbles: true,
+                composed: true,
+                detail: doc,
+              }));
+            }
+          })
+          .catch(function(error) {
+            console.error("Error editing document: ", error);
+          });
+      }
+
+      /**
+       * @private
+       */
+      _computeFirebase(app) {
+        return typeof app == 'string' ? firebase.app(app) : app;
+      }
+
+      /**
+       * @private
+       */
+      __docToObject(doc) {
+        return Object.assign({}, doc.data(), {
+          doc_id: doc.id
+        });
+      }
+
+      /**
+       * @private
+       */
+      __debounce(fn, name) {
+        this._jobs[name] = Polymer.Debouncer.debounce(this._jobs[name],
+          Polymer.Async.microTask, () => fn());
+      }
+
+      /**
+       * @private
+       */
+      __applyFilters(ref) {
+        var req = this.__addFilterOrderBy(ref);
+        if (this.limit) {
+          req = req.limit(this.limit);
+        }
+        return req;
+      }
+
+      /**
+       * @private
+       */
+      __addFilterOrderBy(ref) {
+        var filter = (this.orderBy || '').split(' ');
+        return !filter[0] ? ref :
+          ref.orderBy(filter[0], filter.length > 1 ? filter[1] : 'asc');
+      }
+
+      /**
+       * Fired when a `comment` is added into the Firestore.
+       * _(bubbles: true, composed: true)_
+       * 
+       * The detail of this event is the same as defined in the `hostabee-comment`
+       * element. Excepted it has a property `doc_id` which is the ID of the
+       * document created in the Firestore.
+       * 
+       * @event comment-added
+       * @param {Object} detail The content of the document created in Firestore
+       * plus its ID (as `doc_id` property).
+       */
+
+      /**
+       * Fired when a `comment` is modified in the Firestore.
+       * _(bubbles: true, composed: true)_
+       * 
+       * The detail of this event is the same as defined in the `hostabee-comment`
+       * element. Excepted it has a property `doc_id` which is the ID of the
+       * document updated in the Firestore.
+       * 
+       * @event comment-modified
+       * @param {Object} detail The content of the document updated in Firestore
+       * plus its ID (as `doc_id` property).
+       */
+
+      /**
+       * Fired when a `comment` is removed from the Firestore.
+       * _(bubbles: true, composed: true)_
+       * 
+       * The detail of this event is the same as defined in the `hostabee-comment`
+       * element. Excepted it has a property `doc_id` which is the ID of the
+       * document removed from the Firestore.
+       * 
+       * @event comment-deleted
+       * @param {Object} detail The content of the document removed from the
+       * Firestore plus its ID (as `doc_id` property).
+       */
+
+    }
+
+    window.customElements.define(HostabeeCommentFlowFirebaseConnector.is, HostabeeCommentFlowFirebaseConnector);
+  </script>
+</dom-module>

--- a/test/firebase-config.js
+++ b/test/firebase-config.js
@@ -1,0 +1,10 @@
+// Put the configuration of the app you want to use for running test suites.
+// Required only for demo with Firebase connector.
+(function() {
+  window.HCF = window.HCF || {};
+  // HCF.firebaseConfig = {
+  //   apiKey: "AIza...",
+  //   authDomain: "YOU_APP.firebaseapp.com",
+  //   projectId: "YOU_APP",
+  // };
+})();

--- a/test/hostabee-comment-flow-firebase-connector_integration-test.html
+++ b/test/hostabee-comment-flow-firebase-connector_integration-test.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>hostabee-comment-flow-firebase-connector integration test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="./firebase-config.js"></script>
+
+  <link rel="import" href="../hostabee-comment-flow-firebase-connector.html">
+  <link rel="import" href="../hostabee-comment-flow.html">
+  <script src="https://www.gstatic.com/firebasejs/5.9.0/firebase.js"></script>
+</head>
+
+<body>
+
+  <test-fixture id="WithInputTestFixture">
+    <template>
+      <hostabee-comment-flow-firebase-connector app="firebase-flow">
+        <hostabee-comment-flow slot="input"></hostabee-comment-flow>
+      </hostabee-comment-flow-firebase-connector>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('With input', function() {
+      let element;
+      let firebaseApp;
+
+      const author = {
+        name: 'John Doe'
+      };
+
+      before(function(done) {
+        firebaseApp = firebase.initializeApp(HCF.firebaseConfig, 'firebase-flow');
+        element = fixture('WithInputTestFixture');
+        element.app = firebaseApp;
+        flush(function() {
+          element.flow.author = author;
+          done();
+        });
+      });
+
+      it('should be instantiable with default properties', function() {
+        expect(element.comments).to.be.empty;
+        expect(element.users).to.be.empty;
+        expect(element.commentsCollection).to.be.equal('comments');
+        expect(element.usersCollection).to.be.undefined;
+        expect(element.limit).to.be.equal(0);
+        expect(element.orderBy).to.be.undefined;
+      });
+
+      it('should add comment into the Firestore', function(done) {
+        let spy = sinon.spy(element, 'addComment');
+        element.addEventListener('comment-added', function(event) {
+          expect(spy.calledOnce).to.be.true;
+          element.addComment.restore();
+          expect(event.detail.content).to.be
+            .equal('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+          expect(event.detail['doc_id']).to.be.not.undefined;
+          expect(event.detail['doc_id']).to.be.not.null;
+          done();
+        }, {
+          once: true,
+        });
+        // Submit a comment
+        flush(function() {
+          const form = element.flow.form;
+          form.value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+          form.confirm();
+        });
+      });
+
+      it('should update comment in the Firestore', function(done) {
+        const commentId = Math.round(Math.random() * 100000);
+        // Assertions inside listeners
+        let spy = sinon.spy(element, 'updateComment');
+        element.addEventListener('comment-modified', function(event) {
+          expect(spy.calledOnce).to.be.true;
+          element.updateComment.restore();
+          expect(event.detail.content).to.include(commentId + ' edited');
+          expect(event.detail.author).to.be.deep.equal(author);
+          expect(event.detail.updated).to.be.not.undefined;
+          expect(event.detail.updated).to.be.not.null;
+          expect(event.detail['doc_id']).to.be.not.undefined;
+          expect(event.detail['doc_id']).to.be.not.null;
+          done();
+        }, {
+          once: true,
+        });
+        // Insert comment into Firestore
+        firebaseApp.firestore().collection('comments').add({
+            id: commentId,
+            author,
+            content: 'Lorem ipsum dolor sit amet,',
+            created: new Date(),
+          })
+          .then(function() {
+            element.addEventListener('comments-changed', function() {
+              // Switch to edit mode
+              flush(function() {
+                const comments = Array.from(element.flow.shadowRoot.querySelectorAll('hostabee-comment'));
+                const comment = comments.find((c) => c.item.id == commentId);
+                comment.edit();
+                // Edit existing comment
+                flush(function() {
+                  const textArea = comment.shadowRoot.querySelector('vaadin-text-area');
+                  textArea.value += ` [${commentId} edited]`;
+                  comment.confirmEdit();
+                });
+              });
+            }, {
+              once: true,
+            });
+            // Refresh comment list due to add in Firestore
+            element.fetchComments();
+          });
+      });
+
+      it('should remove comment from the Firestore', function(done) {
+        // Define author and init comment list
+        const commentId = Math.round(Math.random() * 100000);
+        const commentsCount = element.comments.length;
+        const comment = {
+          id: commentId,
+          author,
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+        };
+        // Assertions inside listeners
+        let spy = sinon.spy(element, 'deleteComment');
+        element.addEventListener('comment-deleted', function(event) {
+          expect(spy.calledOnce).to.be.true;
+          element.deleteComment.restore();
+          expect(element.comments.length).to.be.equal(commentsCount);
+          expect(event.detail.author).to.be.deep.equal(comment.author);
+          expect(event.detail.content).to.be.equal(comment.content);
+          expect(event.detail['doc_id']).to.be.not.undefined;
+          expect(event.detail['doc_id']).to.be.not.null;
+          done();
+        }, {
+          once: true,
+        });
+        // Insert comment into Firestore
+        firebaseApp.firestore().collection('comments').add(comment)
+          .then(function() {
+            element.addEventListener('comments-changed', function() {
+              expect(element.comments.length).to.be.equal(commentsCount + 1);
+              // Delete a comment
+              flush(function() {
+                const comments = Array.from(element.flow.shadowRoot.querySelectorAll('hostabee-comment'));
+                comments.find((c) => c.item.id == commentId).delete();
+              });
+            }, {
+              once: true,
+            });
+            // Refresh comment list due to add in Firestore
+            element.fetchComments();
+          });
+      });
+    });
+  </script>
+
+</body>
+
+</html>

--- a/test/hostabee-comment-flow-firebase-connector_test.html
+++ b/test/hostabee-comment-flow-firebase-connector_test.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>hostabee-comment-flow-firebase-connector test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="./firebase-config.js"></script>
+
+  <link rel="import" href="../hostabee-comment-flow-firebase-connector.html">
+  <link rel="import" href="../hostabee-comment-flow.html">
+  <script src="https://www.gstatic.com/firebasejs/5.9.0/firebase.js"></script>
+</head>
+
+<body>
+
+  <test-fixture id="BasicTestFixture">
+    <template>
+      <hostabee-comment-flow-firebase-connector></hostabee-comment-flow-firebase-connector>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="WithInputTestFixture">
+    <template>
+      <hostabee-comment-flow-firebase-connector app="firebase-flow">
+        <hostabee-comment-flow slot="input"></hostabee-comment-flow>
+      </hostabee-comment-flow-firebase-connector>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('Basic', function() {
+      let element;
+      let firebaseApp;
+
+      before(function() {
+        firebaseApp = firebase.initializeApp(HCF.firebaseConfig, 'my-firebase-app');
+      });
+
+      beforeEach(function() {
+        element = fixture('BasicTestFixture');
+      });
+
+      it('should be instantiable with default properties', function() {
+        expect(element.app).to.be.undefined;
+        expect(element.comments).to.be.empty;
+        expect(element.users).to.be.empty;
+        expect(element.commentsCollection).to.be.equal('comments');
+        expect(element.usersCollection).to.be.undefined;
+        expect(element.limit).to.be.equal(0);
+        expect(element.orderBy).to.be.undefined;
+      });
+
+      it('should get comments from Firestore with default config', function(done) {
+        element.addEventListener('comments-changed', function() {
+          expect(element.comments).to.be.not.empty;
+          done();
+        });
+        element.app = firebaseApp;
+      });
+
+      it('should accept Firebase application name instead the app instance', function(done) {
+        element.addEventListener('comments-changed', function() {
+          expect(element.comments).to.be.not.empty;
+          done();
+        });
+        element.app = 'my-firebase-app';
+      });
+
+      it('should get users when collection name is provided', function(done) {
+        element.addEventListener('users-changed', function() {
+          expect(element.users).to.be.not.empty;
+          done();
+        });
+        element.app = firebaseApp;
+        expect(element.users).to.be.empty;
+        element.usersCollection = 'users';
+      });
+    });
+
+    describe('With input', function() {
+      let element;
+      let firebaseApp;
+
+      before(function(done) {
+        firebaseApp = firebase.initializeApp(HCF.firebaseConfig, 'firebase-flow');
+        element = fixture('WithInputTestFixture');
+        element.app = firebaseApp;
+        flush(function() {
+          done();
+        });
+      });
+
+      it('should be instantiable with default properties', function() {
+        expect(element.comments).to.be.empty;
+        expect(element.users).to.be.empty;
+        expect(element.commentsCollection).to.be.equal('comments');
+        expect(element.usersCollection).to.be.undefined;
+        expect(element.limit).to.be.equal(0);
+        expect(element.orderBy).to.be.undefined;
+      });
+
+      it('should add comment into the Firestore', function(done) {
+        let spy = sinon.stub(element, 'addComment');
+        // Submit a comment
+        flush(function() {
+          const form = element.flow.form;
+          form.value = 'New comment my friends!';
+          form.confirm();
+          expect(spy.calledOnce).to.be.true;
+          element.addComment.restore();
+          done();
+        });
+      });
+
+      it('should update comment in the Firestore', function(done) {
+        // Define author and init comment list
+        const john = {
+          name: 'John Doe'
+        };
+        element.flow.author = john;
+        element.flow.comments = [{
+          author: john,
+          content: 'Lorem ipsum dolor sit amet,',
+          created: new Date(),
+        }];
+        let spy = sinon.stub(element, 'updateComment');
+        flush(function() {
+          // Switch to edit mode
+          const comment = element.flow.shadowRoot.querySelector('hostabee-comment');
+          comment.edit();
+          flush(function() {
+            // Edit existing comment
+            comment.shadowRoot.querySelector('vaadin-text-area').value += ' [updated]';
+            comment.confirmEdit();
+            expect(spy.calledOnce).to.be.true;
+            element.updateComment.restore();
+            done();
+          });
+        });
+      });
+
+      it('should remove comment from the Firestore', function(done) {
+        // Define author and init comment list
+        const author = {
+          name: 'John Doe'
+        };
+        element.flow.author = author;
+        element.flow.comments = [{
+          author: author,
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+        }];
+        // Delete a comment
+        let spy = sinon.stub(element, 'deleteComment');
+        flush(function() {
+          element.flow.shadowRoot.querySelector('hostabee-comment').delete();
+          expect(spy.calledOnce).to.be.true;
+          element.deleteComment.restore();
+          done();
+        });
+      });
+    });
+  </script>
+
+</body>
+
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -7,16 +7,27 @@
 
   <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
+  <script src="./firebase-config.js"></script>
 </head>
 
 <body>
   <script>
     // Load and run all tests (.html, .js):
-    WCT.loadSuites([
+    let suites = [
       'hostabee-comment_test.html',
       'hostabee-comment-create-form_test.html',
       'hostabee-comment-flow_test.html',
-    ]);
+    ];
+    // Run integration test suites only when Firebase config is provided.
+    if (HCF.firebaseConfig) {
+      console.log('Integration test suites added to the list.');
+      suites = [
+        ...suites,
+        'hostabee-comment-flow-firebase-connector_test.html',
+        'hostabee-comment-flow-firebase-connector_integration-test.html',
+      ];
+    }
+    WCT.loadSuites(suites);
   </script>
 
 </body>


### PR DESCRIPTION
This commit adds a fresh `hostabee-comment-flow-firebase-connector`
(aka. Firebase connector) element to the collection. This one provide
and easy way to link the `hostabee-comment-flow` to a Firebase app.
Using this connector only few lines of code are required to setup a
Firebase app and store comments into its Firestore.