### PR TITLE
chore(thumbnail): handle case when files are not File

### DIFF
--- a/hostabee-thumbnail-list.html
+++ b/hostabee-thumbnail-list.html
@@ -258,7 +258,11 @@ This program is available under Apache License Version 2.0.
        * given in the parameter.
        */
       _getFileURL(file) {
-        return URL.createObjectURL(file);
+        try {
+          return URL.createObjectURL(file);
+        } catch (error) {
+          console.warn("Can't get URL. Provided files must be instances of File class.", error);
+        }
       }
 
     }


### PR DESCRIPTION
This commit catches the error thrown when the file list does not contain
File class instances and display a warning (instead of the default
uncaught error).