### PR TITLE
fix(form): display of error message

### DIFF
--- a/hostabee-comment-create-form.html
+++ b/hostabee-comment-create-form.html
@@ -16,8 +16,8 @@ This program is available under Apache License Version 2.0.
   <template>
     <style>
       :host {
-        @apply --layout-flex;
         @apply --layout-horizontal;
+        min-height: 38px;
       }
 
       vaadin-text-area {
@@ -32,6 +32,10 @@ This program is available under Apache License Version 2.0.
 
       vaadin-text-area[focused][has-value] {
         min-height: 76px;
+      }
+
+      vaadin-text-area:not([has-value])[invalid] {
+        padding-bottom: 26px;
       }
 
       [part="input-field"] {
@@ -107,6 +111,8 @@ This program is available under Apache License Version 2.0.
      * @customElement
      * @polymer
      * @extends {Polymer.Element}
+
+
      * @memberof Hostabee
      * @demo demo/hostabee-comment-create-form/basic.html Basic
      */

--- a/hostabee-comment-flow.html
+++ b/hostabee-comment-flow.html
@@ -23,6 +23,10 @@ This program is available under Apache License Version 2.0.
         overflow-y: scroll;
         padding-bottom: 10px;
       }
+
+      .form {
+        @apply --layout-flex;
+      }
     </style>
     <div class="comments-container">
       <template is="dom-repeat" items="[[_comments]]" as="comment" restamp>
@@ -30,9 +34,11 @@ This program is available under Apache License Version 2.0.
       </template>
     </div>
     <template is="dom-if" if="[[!readOnly]]" restamp>
-      <slot id="form" name="form">
-        <hostabee-comment-create-form author="[[author]]" language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" minlength="[[minlength]]" on-comment-added="_retargetEvent" allow-files$="[[allowFiles]]"></hostabee-comment-create-form>
-      </slot>
+      <div class="form">
+        <slot id="form" name="form">
+          <hostabee-comment-create-form author="[[author]]" language="[[language]]" locales-folder="[[localesFolder]]" locales-file="[[localesFile]]" minlength="[[minlength]]" on-comment-added="_retargetEvent" allow-files$="[[allowFiles]]"></hostabee-comment-create-form>
+        </slot>
+      </div>
     </template>
     <slot id="mapper" name="mapper"></slot>
   </template>
@@ -196,7 +202,7 @@ This program is available under Apache License Version 2.0.
            * @type {Boolean}
            * @default false
            */
-           allowFiles: {
+          allowFiles: {
             type: Boolean,
             value: false,
           },


### PR DESCRIPTION
Before this commit, the error message was displayed over the button to
attach file to a comment. Now the form lets enough space to display the
error message without going over the button to add a file.