### PR TITLE
fix(form): escape key down event

### DIFF
--- a/hostabee-comment-create-form.html
+++ b/hostabee-comment-create-form.html
@@ -350,7 +350,7 @@ This program is available under Apache License Version 2.0.
         return (event) => {
           if (event.key == 'Escape') {
             event.preventDefault();
-            this.cancel();
+            this.reset();
           } else if (event.key == 'Enter') {
             event.preventDefault();
             this.confirm();


### PR DESCRIPTION
Before the introduction of "cancel" event dispatched when the
cancel button of the form is clicked, the form was simply
cleaned when the user pushed the Escape key. When the
dispatching of "Cancel" event was added the behavior of the
Escape key was impacted. This commit brings the previous
behavior back. Which consists to clear the form when Escape
key is down without dispatching any event.