### PR TITLE
feat(form): input text area required only when minlength set

### DIFF
--- a/hostabee-comment-create-form.html
+++ b/hostabee-comment-create-form.html
@@ -84,7 +84,7 @@ This program is available under Apache License Version 2.0.
     </template>
 
     <div class="form">
-      <vaadin-text-area placeholder="[[localize('PLACEHOLDER_write_a_comment')]]" minlength="[[minlength]]" error-message="[[localize('ERROR_minlength', 'count', minlength)]]" onkeydown="[[_handleKeyDown()]]" value="{{value}}" required></vaadin-text-area>
+      <vaadin-text-area placeholder="[[localize('PLACEHOLDER_write_a_comment')]]" minlength="[[minlength]]" error-message="[[localize('ERROR_minlength', 'count', minlength)]]" onkeydown="[[_handleKeyDown()]]" value="{{value}}" required$="[[_hasMinLength(minlength)]]"></vaadin-text-area>
       <hostabee-thumbnail-list files="{{files}}" limit="[[maxFiles]]" editable></hostabee-thumbnail-list>
       <div class="actions">
         <template is="dom-if" if="[[filePickerButtonVisible]]">
@@ -329,6 +329,13 @@ This program is available under Apache License Version 2.0.
        */
       _filesSelected(event) {
         this.set('files', this.files.concat(...event.target.files));
+      }
+
+      /**
+       * Has the form a minlength set.
+       */
+      _hasMinLength() {
+        return this.minlength > 0;
       }
 
       /**

--- a/test/hostabee-comment-create-form_test.html
+++ b/test/hostabee-comment-create-form_test.html
@@ -109,17 +109,25 @@
         });
       });
 
-      it('should propagate minimum length required to inner text area', function(done) {
+      it('should be required if minlength is higher than 0', function() {
+        element.minlength = 2;
+        const textArea = element.shadowRoot.querySelector('vaadin-text-area');
+        expect(textArea.required).to.be.true;
+      })
+
+      it('should not be required if minlength is equal or lower than 0', function() {
+        element.minlength = 0;
+        const textArea = element.shadowRoot.querySelector('vaadin-text-area');
+        expect(textArea.required).to.be.false;
+      })
+
+      it('should propagate minimum length required to inner text area', function() {
         // Unfortunately, considering the issue https://github.com/vaadin/vaadin-text-field/issues/182
         // we can't programmatically test validation based on minlength requirement.
-        expect(element.minlength).to.be.equal(20);
-        flush(function() {
-          const textArea = element.shadowRoot.querySelector('vaadin-text-area');
-          expect(textArea.minlength).to.be.equal(20);
-          element.minlength = 10;
-          expect(textArea.minlength).to.be.equal(10);
-          done();
-        });
+        const textArea = element.shadowRoot.querySelector('vaadin-text-area');
+        expect(textArea.minlength).to.be.equal(element.minlength);
+        element.minlength = 10;
+        expect(textArea.minlength).to.be.equal(10);
       });
     });
 


### PR DESCRIPTION
Before this commit the text area input was always required. Since a
comment can now have attachments, some users could want to allow send a
comment with pictures only. To do so, the minlength can now to be set
to 0 (or negative value) so the text area does not require a value.