### PR TITLE
fix(form): display of thumbnails on iPhone

### DIFF
--- a/hostabee-thumbnail-list.html
+++ b/hostabee-thumbnail-list.html
@@ -19,7 +19,6 @@ This program is available under Apache License Version 2.0.
         background-color: var(--primary-background-color, #ffffff);
         @apply --layout-horizontal;
         @apply --layout-wrap;
-        @apply --layout-flex;
       }
 
       :host([hidden]) {


### PR DESCRIPTION
Before this commit the thumbnails of selected images on the form to
create a comment were not displayed if they were not at least 3. It was
due to unsupported flex layout. This commit fixes it.