### PR TITLE
chore(i18n): add Spanish, German and Turkish

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,14 @@
+{
+  "ERROR_minlength": "Mindestens {count} Zeichen",
+  "LABEL_edit_your_comment": "Bearbeiten Sie Ihren Kommentar",
+  "PLACEHOLDER_write_a_comment": "Schreibe einen Kommentar...",
+  "anonymous": "{capitalize, select, yes {A} other {a}}nonym",
+  "cancel": "stornieren",
+  "created": "erstellt am ",
+  "delete": "Löschen",
+  "edit": "Bearbeiten",
+  "modified": "geändert am ",
+  "read_more": "Mehr lesen",
+  "save": "sparen",
+  "show_less": "Weniger anzeigen"
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,14 @@
+{
+  "ERROR_minlength": "Al menos {count} caracteres",
+  "LABEL_edit_your_comment": "Edita tu comentario",
+  "PLACEHOLDER_write_a_comment": "Escribir un comentario...",
+  "anonymous": "{capitalize, select, yes {A} other {a}}nónimo",
+  "cancel": "cancelar",
+  "created": "creado el ",
+  "delete": "Borrar",
+  "edit": "Editar",
+  "modified": "modificado el ",
+  "read_more": "Leer más",
+  "save": "salvar",
+  "show_less": "Mostrar menos"
+}

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -1,0 +1,14 @@
+{
+  "ERROR_minlength": "En az {count} karakter",
+  "LABEL_edit_your_comment": "Yorumunuzu düzenleyin",
+  "PLACEHOLDER_write_a_comment": "Bir yorum Yaz...",
+  "anonymous": "{capitalize, select, yes {A} other {a}}nonim",
+  "cancel": "iptal etmek",
+  "created": "tarihinde yaratılmıştır ",
+  "delete": "Silmek",
+  "edit": "Düzenle",
+  "modified": "tarihinde değiştirilmiştir ",
+  "read_more": "Daha fazla oku",
+  "save": "kayıt etmek",
+  "show_less": "Daha az göster"
+}


### PR DESCRIPTION
This commit adds locales to support German, Spanish and Turkish by
default.